### PR TITLE
Fix pip install issue.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include README.md
+include CHANGELOG.md
+include LICENSE.md
+recursive-include tests *

--- a/setup.py
+++ b/setup.py
@@ -30,5 +30,5 @@ setup(
         'argparse',
         'sc2reader==1.2.0',
     ],
-    packages=find_packages(),
+    packages=find_packages(exclude=['tests']),
 )


### PR DESCRIPTION
Add MANIFEST.in and exclude tests in setup.py in order to
exclude tests from being added to site-packages, but still
included in the sdist. README and CHANGELOG is needed to
build from sdist.