### PR TITLE
fix: typo in constant causing KeyError

### DIFF
--- a/spawningtool/lotv_constants.py
+++ b/spawningtool/lotv_constants.py
@@ -835,7 +835,7 @@ BUILD_DATA = {
     },
     "InterferenceMatrix": {  # added 5.0.12
         "build_time": 57,
-        "build_from": [ "TechLab" ],
+        "built_from": [ "TechLab" ],
         "display_name": "Interference Matrix"
     },
     # fusion core


### PR DESCRIPTION
Small typo fix which causes KeyError in https://github.com/StoicLoofah/spawningtool/blob/1e129081f7a36a37d3d4bdcaa1971fcbb995b592/spawningtool/parser.py#L746

Now I am a bit confused why this code (adjust chronoboost time) would run anyway on a TvZ replay. I checked the tracker events and they appear to have 'ChronoBoostEnergyCost' abilities. Not sure if this is expected behavior or maybe a bug in sc2reader? I have attached the replay. 

The fix should be fine either way. 

[Amygdala (42) TvZ with chrono boost.zip](https://github.com/user-attachments/files/18481784/Amygdala.42.TvZ.with.chrono.boost.zip)
